### PR TITLE
Add @apdavison and @samuelgarcia as maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,4 +41,6 @@ about:
 
 extra:
   recipe-maintainers:
+    - apdavison
     - jakirkham
+    - samuelgarcia


### PR DESCRIPTION
This PR adds @apdavison and @samuelgarcia as maintainers per our [discussion](https://github.com/conda-forge/staged-recipes/pull/719#issuecomment-225523772).

As this is the first time for both of you signing up as maintainers, I would like to explain the process a bit. Now that both of your GitHub handles are listed here, an automated script will come by at some point and notice that neither of you are currently part of the `python-neo` team. It will attempt to add both of you to the `python-neo` team so both of you have rights on this repo. However, as both of you are not in conda-forge yet, this will trigger GitHub to send both of you an email, which invites both of you to join conda-forge. Once accepted both of you will be added to the `python-neo` team and a general team ( `all-members` ). From now on, anything either of you add yourself to or others add either of you to (with your expressed permission) will result in automatic addition to those teams by this automation script.

If either of you have and questions or concerns, please let me know. Welcome to conda-forge. 😄
