### PR TITLE
Bump to version 0.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "neo" %}
-{% set version = "0.3.3" %}
+{% set version = "0.4.1" %}
 
 package:
   name: python-{{ name }}
@@ -8,7 +8,7 @@ package:
 source:
   fn: python-{{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  md5: 98e7e8948158f4492fc94d9d44367c91
+  md5: f706df3a1bce835cb490b812ac198a6e
 
 build:
   number: 0


### PR DESCRIPTION
Closes https://github.com/conda-forge/python-neo-feedstock/pull/2
